### PR TITLE
fix: image path passed to storage in task

### DIFF
--- a/src/tasks/imageDeleteCron.js
+++ b/src/tasks/imageDeleteCron.js
@@ -4,13 +4,15 @@ import { data } from "@ampt/data";
 const imageStorage = storage("images");
 
 const imageDeleteTask = task(
-  "Delete Not Bookmarked Images Every Day",
+  "Delete Non-Bookmarked Images Every Day",
   async (event) => {
     // This code block will run at 1 am every day
     let tempImageList = await data.get("temporaryImageStore");
 
     for (let imageI = 0; imageI < tempImageList.length; imageI++) {
-      await imageStorage.remove(`/generatedImage/${tempImageList[imageI]}`);
+      await imageStorage.remove(
+        `/generatedImage/${tempImageList[imageI].imageId}`
+      );
     }
     await data.set("temporaryImageStore", []);
   }


### PR DESCRIPTION
- the dynamic path generated and passed to the storage function to delete the image was invalid as the code resolved it to an object because of a missing key. Now reading imageId from the object which resolves to correct path.