### PR TITLE
fix: remove enter spacing if any from prompt

### DIFF
--- a/src/controller/imageGenerater.controller.js
+++ b/src/controller/imageGenerater.controller.js
@@ -14,7 +14,7 @@ const generateImage = async (req, res) => {
       headers: {
         "Content-Type": "text/plain",
       },
-      data: req.body.prompt,
+      data: req.body.prompt.replace(/(\r\n|\n|\r)/gm, ""),
       responseType: "arraybuffer",
     };
 


### PR DESCRIPTION
- bedrock does not accept text as prompt with enter in it. Throws internal error. Hence, removing enter from prompt.